### PR TITLE
update to akka 2.5.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -28,7 +28,7 @@ object Build extends sbt.Build {
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
   lazy val sonatypeSnapshot = "Sonatype Snapshots Repository" at "https://oss.sonatype.org/content/repositories/snapshots/"
-  lazy val akkaVersion = "2.5.1"
+  lazy val akkaVersion = "2.5.8"
 
   lazy val root = Project(id = "akka-kryo-serialization", base = file(".")).settings(
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -28,7 +28,7 @@ object Build extends sbt.Build {
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
   lazy val sonatypeSnapshot = "Sonatype Snapshots Repository" at "https://oss.sonatype.org/content/repositories/snapshots/"
-  lazy val akkaVersion = "2.4.12"
+  lazy val akkaVersion = "2.5.1"
 
   lazy val root = Project(id = "akka-kryo-serialization", base = file(".")).settings(
 


### PR DESCRIPTION
Akka 2.5.x is actually backwards binary (sic) compatible with 2.4.x so using this lib should just work in Akka 2.5 projects, however it would be good to update it to the latest series regardless.

Only question remains is which version you'd want to call this and release this in then?

Resolves https://github.com/romix/akka-kryo-serialization/issues/116