### PR TITLE
Replace ConcurrentLinkedQueue by Agrona bounded MPMC

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
 
             idstrategy = "incremental"
 
-            # Define a default queue builder, by default ConcurrentLinkedQueue is used.
+            # Define a default queue builder, by default a bounded non-blocking queue is used.
             # Create your own queue builder by implementing the trait QueueBuilder,
             # useful for paranoid GC users that want to use JCtools MpmcArrayQueue for example.
             #
@@ -296,35 +296,31 @@ whole object graph with this object as a root using this Java serializer.
 Kryo queue builder examples:
 ----------------------------
 
-* Scala bounded queue builder with a capacity of 32:
-
-        package a.b.c
+* Scala bounded queue builder with a capacity of CPUs x 4:
 
         import akka.serialization.Serializer
         import com.romix.akka.serialization.kryo.QueueBuilder
-        import org.jctools.queues.MpmcArrayQueue
+        import org.agrona.concurrent.ManyToManyConcurrentArrayQueue
         import java.util.Queue
 
         class KryoQueueBuilder extends QueueBuilder {
           def build: Queue[Serializer] = {
-            new MpmcArrayQueue[Serializer](32)
+            new ManyToManyConcurrentArrayQueue[Serializer](Runtime.getRuntime.availableProcessors * 4)
           }
         }
 
-* Java bounded queue builder with a capacity of 32:
-
-        package a.b.c;
+* Java bounded queue builder with a capacity of CPUs x 4:
 
         import akka.serialization.Serializer;
         import com.romix.akka.serialization.kryo.QueueBuilder;
-        import org.jctools.queues.MpmcArrayQueue;
+        import org.agrona.concurrent.ManyToManyConcurrentArrayQueue
         import java.util.Queue;
 
         public class KryoQueueBuilder implements QueueBuilder {
 
           @Override
           public Queue<Serializer> build() {
-            return new MpmcArrayQueue<>(32);
+            return new ManyToManyConcurrentArrayQueue<>(Runtime.getRuntime().availableProcessors() * 4);
           }
         }
 

--- a/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
+++ b/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
@@ -20,7 +20,6 @@ package com.romix.akka.serialization.kryo
 
 import java.security.SecureRandom
 import java.util
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.zip.{Deflater, Inflater}
 
 import javax.crypto.Cipher
@@ -35,6 +34,7 @@ import com.esotericsoftware.kryo.util._
 import com.esotericsoftware.minlog.{Log => MiniLog}
 import com.romix.scala.serialization.kryo.{ScalaKryo, _}
 import net.jpountz.lz4.LZ4Factory
+import org.agrona.concurrent.ManyToManyConcurrentArrayQueue
 import org.objenesis.strategy.StdInstantiatorStrategy
 
 import scala.collection.mutable.ArrayBuilder
@@ -533,7 +533,7 @@ class SerializerPool(queueBuilder: QueueBuilder, newInstance: () => Serializer) 
 
   private val pool =
     if (queueBuilder == null)
-      new ConcurrentLinkedQueue[Serializer]
+      new ManyToManyConcurrentArrayQueue[Serializer](Runtime.getRuntime.availableProcessors * 4)
     else
       queueBuilder.build
 
@@ -556,7 +556,7 @@ class SerializerPool(queueBuilder: QueueBuilder, newInstance: () => Serializer) 
 /**
   * Kryo custom queue builder, to replace ConcurrentLinkedQueue for another Queue,
   * Notice that it must be a multiple producer and multiple consumer queue type,
-  * you could use for example JCtools MpmcArrayQueue.
+  * you could use for example a bounded non-blocking queue.
   */
 trait QueueBuilder {
 


### PR DESCRIPTION
Replace ConcurrentLinkedQueue by Agrona bounded Multiple Producer-Multiple Consumer.

The reasoning for this is GC, users using the default queue if sending/receiving many small messages will generate GC because of the linked data structure.

No dependency is needed because `akka-remote` depends on `aeron` which depends on `agrona`

**Note:** I have also updated few dependencies like Akka, Kryo, etc, also it fixes #117