### PR TITLE
update akka

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,21 +14,18 @@
  * limitations under the License.
  ******************************************************************************/
 
-import sbt._
-import Keys._
 import com.typesafe.sbt.osgi._
-import sbtrelease._
+import sbt.Keys._
+import sbt._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
-import sbtrelease.ReleaseStateTransformations._
-import com.typesafe.sbt.pgp.PgpKeys
-import ReleaseTransformations._
 
 object Build extends sbt.Build {
 
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
   lazy val sonatypeSnapshot = "Sonatype Snapshots Repository" at "https://oss.sonatype.org/content/repositories/snapshots/"
-  lazy val akkaVersion = "2.4.12"
+  lazy val akkaVersion = "2.5.17"
 
   lazy val root = Project(id = "akka-kryo-serialization", base = file(".")).settings(
 
@@ -37,7 +34,7 @@ object Build extends sbt.Build {
     resolvers += typesafeSnapshot,
     resolvers += sonatypeSnapshot,
     // publishArtifact in packageDoc := false,
-    scalaVersion := "2.12.0",
+    scalaVersion := "2.12.7",
     crossScalaVersions := Seq(scalaVersion.value, "2.11.8"),
     libraryDependencies += "com.typesafe.akka" %% "akka-remote" % akkaVersion,
     libraryDependencies += "com.esotericsoftware" % "kryo" % "4.0.0",


### PR DESCRIPTION
After updating to the latest PlayFramework I was getting a strongly worded message that akka-remote was lagging behind.  Turns out it is included from my use of akka-kyro-serialization. 
```
[warn] a.u.ManifestInfo - Detected possible incompatible versions on the classpath. Please note that a given Akka version MUST be the same across all modules of Akka that you are using, e.g. if you use [2.5.17] all other modules that are released together MUST be of the same version. Make sure you're using a compatible set of libraries.Possibly confl
icting versions [2.5.17, 2.4.12] in libraries [akka-protobuf:2.5.17, akka-actor:2.5.17, akka-slf4j:2.5.17, akka-remote:2.4.12, akka-stream:2.5.17]
```