### PR TITLE
Switches to kryo shaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ How to use this library in your project
 ---------------------------------------
 
 We provide several versions of the library:
+* (upcoming) v1.1.0 is build against Akka-2.5 and Kryo-4.0 and is available for Scala-2.12 and Scala-2.13
+  this version is tested with JDK: OpenJdk8,OpenJdk11 and Scala: 2.12.10,2.13.1 and Akka: 2.5.25,2.6.0-M7
 * v1.0.0 is build against Akka-2.5 and Kryo-4.0 and is available for Scala-2.11, Scala-2.12 and Scala-2.13
   this version is tested with JDK: OpenJdk8,OpenJdk11 and Scala: 2.11.12,2.12.10,2.13.1 and Akka: 2.5.25,2.6.0-M7
   
@@ -353,6 +355,25 @@ And finally declare the custom serializer in the `akka.actor.serializers` sectio
         kryo-xyz = "xyz.XyzKryoSerializer"
     }
 ```
+
+
+Kryo shaded and ASM
+-----------------------------
+Kryo depends on [ASM](https://asm.ow2.io), which is used by many different projects in different versions.
+This can lead to unintended version conflicts. To avoid this, Kryo provides a [shaded](https://maven.apache.org/plugins/maven-shade-plugin/) 
+version to work around this issue. For easier usage we depend on the shaded Kryo. Note that only the ASM dependency is shaded and not kryo itself.
+
+
+If you prefer to re-use Kryo you can override the dependency (but be sure to pick compatible versions):
+    
+```scala
+lazy val kryoSerializationDeps = Seq(
+  "io.altoo" %% "akka-kryo-serialization" % "1.0.0" excludeAll(ExclusionRule("com.esotericsoftware", "kryo-shaded")),
+  "com.esotericsoftware" % "kryo" % "4.0.2"
+)
+```
+    
+If this would be a common use case we could provide different artifacts with both dependencies.
 
 
 How do I build this library on my own?

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ scalaVersion := "2.13.1"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.10")
 
 libraryDependencies += "com.typesafe.akka" %% "akka-remote" % akkaVersion
-libraryDependencies += "com.esotericsoftware" % "kryo" % "4.0.2"
+libraryDependencies += "com.esotericsoftware" % "kryo-shaded" % "4.0.2"
 libraryDependencies += "org.lz4" % "lz4-java" % "1.6.0"
 libraryDependencies += "commons-io" % "commons-io" % "2.6" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"


### PR DESCRIPTION
Switching to kryo shaded as default since it probably the easiest way to use.
(Dedicated artifact options could be provided if they'd be commonly used tough)