### PR TITLE
Add Scala IndexedSeq classes to basic mappings

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -197,5 +197,24 @@ akka-kryo-serialization {
     "java.time.ZonedDateTime" = 76
     "java.time.Instant" = 77
     "java.time.Duration" = 78
+    
+    // more scala
+    "scala.collection.immutable.Vector0$" = 79
+    "scala.collection.immutable.Vector1" = 80
+    "scala.collection.immutable.Vector2" = 81
+    "scala.collection.immutable.Vector3" = 82
+    "scala.collection.immutable.Vector4" = 83
+    "scala.collection.immutable.Vector5" = 84
+    "scala.collection.immutable.Vector6" = 85
+    "scala.collection.immutable.ArraySeq$ofRef" = 86
+    "scala.collection.immutable.ArraySeq$ofInt" = 87
+    "scala.collection.immutable.ArraySeq$ofDouble" = 88
+    "scala.collection.immutable.ArraySeq$ofLong" = 89
+    "scala.collection.immutable.ArraySeq$ofFloat" = 90
+    "scala.collection.immutable.ArraySeq$ofChar" = 91
+    "scala.collection.immutable.ArraySeq$ofByte" = 92
+    "scala.collection.immutable.ArraySeq$ofShort" = 93
+    "scala.collection.immutable.ArraySeq$ofBoolean" = 94
+    "scala.collection.immutable.ArraySeq$ofUnit" = 95
   }
 }


### PR DESCRIPTION
Not sure if you'll merge as-is because it is technically API-breaking, but this adds the main IndexedSeq implementations (imho, Vector and ArraySeq) to the basic mappings.

If you want to avoid breaking the API, can I suggest adding a new section to the `reference.conf` e.g. `optional-scala-collections-mappings` or such?

Thanks for considering.