### PR TITLE
Add serializer for typed.ActorRef

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ scalaVersion := "2.13.3"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.12")
 
 libraryDependencies += "com.typesafe.akka" %% "akka-actor" % akkaVersion
+libraryDependencies += "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion
 libraryDependencies += "com.esotericsoftware" % "kryo" % kryoVersion
 libraryDependencies += "org.lz4" % "lz4-java" % "1.7.1"
 libraryDependencies += "org.agrona" % "agrona" % "1.7.2" // should match akka-remote/aeron inherited version
@@ -33,6 +34,7 @@ libraryDependencies += "commons-io" % "commons-io" % "2.6" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % "test"
 libraryDependencies += "com.typesafe.akka" %% "akka-persistence" % akkaVersion % "test"
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test"
+libraryDependencies += "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % "test"
 
 unmanagedSourceDirectories in Compile += {
   scalaBinaryVersion.value match {

--- a/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
+++ b/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
@@ -1,8 +1,9 @@
 package io.altoo.akka.serialization.kryo
 
 import akka.actor.{ActorRef, ExtendedActorSystem}
+import akka.actor.typed
 import com.esotericsoftware.kryo.serializers.FieldSerializer
-import io.altoo.akka.serialization.kryo.serializer.akka.{ActorRefSerializer, ByteStringSerializer}
+import io.altoo.akka.serialization.kryo.serializer.akka.{ActorRefSerializer, ByteStringSerializer, TypedActorRefSerializer}
 import io.altoo.akka.serialization.kryo.serializer.scala._
 
 import scala.util.{Failure, Success}
@@ -26,6 +27,7 @@ class DefaultKryoInitializer {
   def initAkkaSerializer(kryo: ScalaKryo, system: ExtendedActorSystem): Unit = {
     kryo.addDefaultSerializer(classOf[akka.util.ByteString], classOf[ByteStringSerializer])
     kryo.addDefaultSerializer(classOf[ActorRef], new ActorRefSerializer(system))
+    kryo.addDefaultSerializer(classOf[typed.ActorRef[Nothing]], new TypedActorRefSerializer(typed.ActorSystem.wrap(system)))
   }
 
   /**

--- a/src/main/scala/io/altoo/akka/serialization/kryo/serializer/akka/TypedActorRefSerializer.scala
+++ b/src/main/scala/io/altoo/akka/serialization/kryo/serializer/akka/TypedActorRefSerializer.scala
@@ -1,0 +1,42 @@
+/**
+ * *****************************************************************************
+ * Copyright 2012 Roman Levenstein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ****************************************************************************
+ */
+
+package io.altoo.akka.serialization.kryo.serializer.akka
+
+import akka.actor.typed.{ActorRef, ActorRefResolver, ActorSystem}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+
+/**
+ * Specialized serializer for typed actor refs.
+ *
+ * @author Arman Bilge
+ */
+class TypedActorRefSerializer(val system: ActorSystem[Nothing]) extends Serializer[ActorRef[Nothing]] {
+
+  val resolver = ActorRefResolver(system)
+
+  override def read(kryo: Kryo, input: Input, typ: Class[_ <: ActorRef[Nothing]]): ActorRef[Nothing] = {
+    val path = input.readString()
+    resolver.resolveActorRef(path)
+  }
+
+  override def write(kryo: Kryo, output: Output, obj: ActorRef[Nothing]): Unit = {
+    output.writeString(resolver.toSerializationFormat(obj))
+  }
+}

--- a/src/test/scala/io/altoo/akka/serialization/kryo/serializer/akka/TypedActorRefSerializerTest.scala
+++ b/src/test/scala/io/altoo/akka/serialization/kryo/serializer/akka/TypedActorRefSerializerTest.scala
@@ -1,0 +1,62 @@
+package io.altoo.akka.serialization.kryo.serializer.akka
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.Behaviors
+import akka.serialization.SerializationExtension
+import com.typesafe.config.ConfigFactory
+import io.altoo.akka.serialization.kryo.KryoSerializer
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+object TypedActorRefSerializerTest {
+  private val testConfig =
+    """
+      |akka {
+      |  actor {
+      |    serializers {
+      |      kryo = "io.altoo.akka.serialization.kryo.KryoSerializer"
+      |    }
+      |    serialization-bindings {
+      |      "akka.actor.typed.ActorRef" = kryo
+      |      "akka.actor.typed.internal.adapter.ActorRefAdapter" = kryo
+      |    }
+      |  }
+      |}
+      |akka-kryo-serialization {
+      |  trace = true
+      |  id-strategy = "default"
+      |  implicit-registration-logging = true
+      |  post-serialization-transformations = off
+      |}
+      |""".stripMargin
+}
+
+class TypedActorRefSerializerTest extends AnyFlatSpecLike with BeforeAndAfterAll with Matchers {
+
+  private val testKit = ActorTestKit("testSystem", ConfigFactory.parseString(TypedActorRefSerializerTest.testConfig))
+  private val serialization = SerializationExtension(testKit.system.classicSystem)
+  private trait Msg
+
+  behavior of "TypedActorRefSerializer"
+
+  it should "serialize and deserialize actorRef" in {
+    val value: ActorRef[Msg] = testKit.spawn(Behaviors.ignore[Msg])
+
+    // serialize
+    val serializer = serialization.findSerializerFor(value)
+    serializer shouldBe a[KryoSerializer]
+
+    val serialized = serialization.serialize(value)
+    serialized.isSuccess shouldBe true
+
+    // deserialize
+    val deserialized = serialization.deserialize(serialized.get, classOf[ActorRef[Msg]])
+    deserialized.isSuccess shouldBe true
+    deserialized.get shouldBe value
+  }
+
+  override def afterAll(): Unit = testKit.shutdownTestKit()
+
+}


### PR DESCRIPTION
Implements a serializer for the Akka Typed API's ActorRef. This does add a new dependency to `akka-actor-typed`, but given that the typed API is the future of Akka I think that this is reasonable.

I hoped to add tests; however it seems your current tests for classic (non-typed) ActorRef serialization may be broken (?). Fixing them seemed beyond this scope of this PR; however, I'd be happy to do so in a followup PR.

Thanks for your consideration.