### PR TITLE
Pass ActorSystem to all initialization hooks in DefaultKryoInitializer

### DIFF
--- a/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
+++ b/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
@@ -17,9 +17,17 @@ class DefaultKryoInitializer {
    * Can be overridden to set a different field serializer before other serializer are initialized.
    * Note: register custom classes/serializer in `postInit`, otherwise default order might break.
    */
-  def preInit(kryo: ScalaKryo): Unit = {
+  def preInit(kryo: ScalaKryo, system: ExtendedActorSystem): Unit = {
     kryo.setDefaultSerializer(classOf[com.esotericsoftware.kryo.serializers.FieldSerializer[_]])
+    preInit(kryo)
   }
+
+  /**
+   * Can be overridden to set a different field serializer before other serializer are initialized.
+   * Note: register custom classes/serializer in `postInit`, otherwise default order might break.
+   */
+  @deprecatedOverriding("Use preInit(kryo,system) instead", since = "2.0.0")
+  def preInit(kryo: ScalaKryo): Unit = ()
 
   /**
    * Registers serializer for standard akka classes - override only if you know what you are doing!
@@ -69,5 +77,13 @@ class DefaultKryoInitializer {
   /**
    * Can be overridden to register additional serializer and classes explicitely or reconfigure kryo.
    */
+  def postInit(kryo: ScalaKryo, system: ExtendedActorSystem): Unit = {
+    postInit(kryo)
+  }
+
+  /**
+   * Can be overridden to register additional serializer and classes explicitely or reconfigure kryo.
+   */
+  @deprecatedOverriding("Use postInit(kryo,system) instead", since = "2.0.0")
   def postInit(kryo: ScalaKryo): Unit = ()
 }

--- a/src/main/scala/io/altoo/akka/serialization/kryo/KryoSerializer.scala
+++ b/src/main/scala/io/altoo/akka/serialization/kryo/KryoSerializer.scala
@@ -199,7 +199,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
     val initializer = kryoInitializerClass.getDeclaredConstructor().newInstance()
 
     // setting default serializer
-    initializer.preInit(kryo)
+    initializer.preInit(kryo, system)
     // akka byte string serializer must be registered before generic scala collection serializer
     initializer.initAkkaSerializer(kryo, system)
     initializer.initScalaSerializer(kryo, system)
@@ -229,7 +229,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
       }
     }
 
-    initializer.postInit(kryo)
+    initializer.postInit(kryo, system)
 
     classResolver match {
       // Now that we're done with registration, turn on the SubclassResolver:


### PR DESCRIPTION
Sorry to bug you with another PR!

This change passes the `ExtendedActorSystem` to all four initialization hooks in `DefaultKryoInitializer`. My use-case is that in my custom initializer extending this class, I'd like to access my config (via the system) in the `postInit` hook.

I implemented this so it still supports the old hooks to avoid breaking the API; however, they are marked as deprecated.

Thanks again for considering my proposal.