### PR TITLE
Bug fix: Update fields after updating FieldSerializerConfig

### DIFF
--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/serializer/scala/ScalaKryo.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/serializer/scala/ScalaKryo.scala
@@ -43,6 +43,7 @@ class ScalaKryo(classResolver: ClassResolver, referenceResolver: ReferenceResolv
           //We also enable it by default in java since not wanting these fields
           //serialized looks like the exception rather than the rule.
           fs.getFieldSerializerConfig.setIgnoreSyntheticFields(false)
+          fs.updateFields()
           fs
         case x: Serializer[_] => x
       }


### PR DESCRIPTION
The docs for `FieldSerializer.getFieldSerializerConfig()` state that:
> If the returned config settings are modified, updateFields() must be called.