### PR TITLE
Serialize actor refs with `writeAscii`

### DIFF
--- a/akka-kryo-serialization-typed/src/main/scala/io/altoo/akka/serialization/kryo/typed/serializer/TypedActorRefSerializer.scala
+++ b/akka-kryo-serialization-typed/src/main/scala/io/altoo/akka/serialization/kryo/typed/serializer/TypedActorRefSerializer.scala
@@ -37,6 +37,6 @@ class TypedActorRefSerializer(val system: ActorSystem[Nothing]) extends Serializ
   }
 
   override def write(kryo: Kryo, output: Output, obj: ActorRef[Nothing]): Unit = {
-    output.writeString(resolver.toSerializationFormat(obj))
+    output.writeAscii(resolver.toSerializationFormat(obj))
   }
 }

--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/serializer/akka/ActorRefSerializer.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/serializer/akka/ActorRefSerializer.scala
@@ -36,6 +36,6 @@ class ActorRefSerializer(val system: ExtendedActorSystem) extends Serializer[Act
   }
 
   override def write(kryo: Kryo, output: Output, obj: ActorRef): Unit = {
-    output.writeString(Serialization.serializedActorPath(obj))
+    output.writeAscii(Serialization.serializedActorPath(obj))
   }
 }


### PR DESCRIPTION
A small optimization: [ActorRefs are pure ASCII](https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/actor/ActorPath.scala#L102) so can be serialized with Kryo's optimized `writeAscii` method. Note that `readString` is still used for deserialization so this change is non-breaking/backwards compatible.