### PR TITLE
Implement the `ByteBufferSerializer` interface

### DIFF
--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/DefaultQueueBuilder.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/DefaultQueueBuilder.scala
@@ -1,9 +1,11 @@
 package io.altoo.akka.serialization.kryo
 
 import java.util
-
 import akka.serialization.Serializer
 import org.agrona.concurrent.ManyToManyConcurrentArrayQueue
+
+import scala.annotation.nowarn
+import scala.reflect.ClassTag
 
 /**
  * Default queue builder that can be extended to use another type of queue.
@@ -14,5 +16,11 @@ class DefaultQueueBuilder {
   /**
    * Override to use a different queue.
    */
+  @deprecated("Deprecated in favor of build[T]", since = "2.2.0")
   def build: util.Queue[Serializer] = new ManyToManyConcurrentArrayQueue[Serializer](Runtime.getRuntime.availableProcessors * 4)
+
+  /**
+   * Override to use a different queue.
+   */
+  def build[T: ClassTag]: util.Queue[T] = build.asInstanceOf[util.Queue[T]]: @nowarn("msg=deprecated") // Type-erasure hack
 }

--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/KryoSerializerBackend.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/KryoSerializerBackend.scala
@@ -1,18 +1,23 @@
 package io.altoo.akka.serialization.kryo
 
+import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
-import akka.serialization.Serializer
+import akka.serialization.{ByteBufferSerializer, Serializer}
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.io.{ByteBufferInput, ByteBufferOutput, Input, Output}
 import com.esotericsoftware.kryo.unsafe.{UnsafeInput, UnsafeOutput}
 
+import java.nio.ByteBuffer
+import scala.util.Success
+
 @InternalApi
-private[kryo] class KryoSerializerBackend(val kryo: Kryo, val bufferSize: Int, val maxBufferSize: Int, val includeManifest: Boolean, val useUnsafe: Boolean)(log: LoggingAdapter) extends Serializer {
+private[kryo] class KryoSerializerBackend(val kryo: Kryo, val bufferSize: Int, val maxBufferSize: Int, val includeManifest: Boolean, val useUnsafe: Boolean)(system: ExtendedActorSystem, log: LoggingAdapter) extends Serializer with ByteBufferSerializer {
   // A unique identifier for this Serializer
   def identifier = 12454323
 
   // "toBinary" serializes the given object to an Array of Bytes
+  // Implements Serializer
   override def toBinary(obj: AnyRef): Array[Byte] = {
     val buffer = output
     try {
@@ -30,9 +35,26 @@ private[kryo] class KryoSerializerBackend(val kryo: Kryo, val bufferSize: Int, v
     }
   }
 
+  // Implements ByteBufferSerializer
+  override def toBinary(obj: AnyRef, buf: ByteBuffer): Unit = {
+    val buffer = getOutput(buf)
+    try {
+      if (includeManifest)
+        kryo.writeObject(buffer, obj)
+      else
+        kryo.writeClassAndObject(buffer, obj)
+      buffer.toBytes
+    } catch {
+      case e: StackOverflowError if !kryo.getReferences => // when configured with "nograph" serialization can fail with stack overflow
+        log.error(e, "Could not serialize class with potentially circular references: {}", obj)
+        throw new RuntimeException("Could not serialize class with potential circular references: " + obj)
+    }
+  }
+
   // "fromBinary" deserializes the given array,
   // using the type hint (if any, see "includeManifest" above)
   // into the optionally provided classLoader.
+  // Implements Serializer
   override def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
     val buffer = getInput(bytes)
     try {
@@ -48,16 +70,39 @@ private[kryo] class KryoSerializerBackend(val kryo: Kryo, val bufferSize: Int, v
     }
   }
 
+  // Implements ByteBufferSerializer
+  override def fromBinary(buf: ByteBuffer, manifest: String): AnyRef = {
+    val buffer = getInput(buf)
+    val clazz = system.dynamicAccess.getClassFor[AnyRef](manifest)
+    if (includeManifest)
+      clazz match {
+        case Success(c) => kryo.readObject(buffer, c).asInstanceOf[AnyRef]
+        case _ => throw new RuntimeException("Object of unknown class cannot be deserialized")
+      }
+    else
+      kryo.readClassAndObject(buffer)
+  }
+
+  // Used by Serializer implementation
   private val output =
     if (useUnsafe)
       new UnsafeOutput(bufferSize, maxBufferSize)
     else
       new Output(bufferSize, maxBufferSize)
 
+  // Used by ByteBufferSerializer implementation
+  private def getOutput(buffer: ByteBuffer): Output =
+    new ByteBufferOutput(buffer)
+
+  // Used by Serializer implementation
   private def getInput(bytes: Array[Byte]): Input =
     if (useUnsafe)
       new UnsafeInput(bytes)
     else
       new Input(bytes)
+
+  // Used by ByteBufferSerializer implementation
+  private def getInput(buffer: ByteBuffer): Input =
+    new ByteBufferInput(buffer)
 
 }

--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/SerializerPool.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/SerializerPool.scala
@@ -1,7 +1,6 @@
 package io.altoo.akka.serialization.kryo
 
 import akka.annotation.InternalApi
-import akka.serialization.Serializer
 
 /**
  * Returns a SerializerPool, useful to reduce GC overhead.
@@ -10,22 +9,22 @@ import akka.serialization.Serializer
  * @param newInstance  Serializer instance builder.
  */
 @InternalApi
-private[kryo] class SerializerPool(queueBuilder: DefaultQueueBuilder, newInstance: () => Serializer) {
+private[kryo] class SerializerPool(queueBuilder: DefaultQueueBuilder, newInstance: () => KryoSerializerBackend) {
 
-  private val pool = queueBuilder.build
+  private val pool = queueBuilder.build[KryoSerializerBackend]
 
-  def fetch(): Serializer = {
+  def fetch(): KryoSerializerBackend = {
     pool.poll() match {
       case null => newInstance()
       case o => o
     }
   }
 
-  def release(o: Serializer): Unit = {
+  def release(o: KryoSerializerBackend): Unit = {
     pool.offer(o)
   }
 
-  def add(o: Serializer): Unit = {
+  def add(o: KryoSerializerBackend): Unit = {
     pool.add(o)
   }
 }

--- a/akka-kryo-serialization/src/test/scala/io/altoo/akka/serialization/kryo/CryptoSerializationTest.scala
+++ b/akka-kryo-serialization/src/test/scala/io/altoo/akka/serialization/kryo/CryptoSerializationTest.scala
@@ -1,12 +1,13 @@
 package io.altoo.akka.serialization.kryo
 
 import akka.actor.ActorSystem
-import akka.serialization.SerializationExtension
+import akka.serialization.{ByteBufferSerializer, SerializationExtension}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.ByteBuffer
 import scala.collection.immutable.HashMap
 
 object CryptoSerializationTest {
@@ -68,5 +69,14 @@ class CryptoSerializationTest extends AnyFlatSpec with Matchers with BeforeAndAf
     val serialized = serializer.toBinary(atm)
     val deserialized = deserializer.fromBinary(serialized)
     atm shouldBe deserialized
+
+    val bufferSerializer = sourceSerialization.findSerializerFor(atm).asInstanceOf[ByteBufferSerializer]
+    val bufferDeserializer = targetSerialization.findSerializerFor(atm).asInstanceOf[ByteBufferSerializer]
+
+    val bb = ByteBuffer.allocate(serialized.length * 2)
+    bufferSerializer.toBinary(atm, bb)
+    bb.flip()
+    val bufferDeserialized = bufferDeserializer.fromBinary(bb, atm.getClass.toString)
+    atm shouldBe bufferDeserialized
   }
 }

--- a/akka-kryo-serialization/src/test/scala/io/altoo/akka/serialization/kryo/TransformationSerializationTest.scala
+++ b/akka-kryo-serialization/src/test/scala/io/altoo/akka/serialization/kryo/TransformationSerializationTest.scala
@@ -1,11 +1,13 @@
 package io.altoo.akka.serialization.kryo
 
-import akka.serialization.SerializationExtension
+import akka.serialization.{ByteBufferSerializer, SerializationExtension}
 import com.typesafe.config.ConfigFactory
 import io.altoo.akka.serialization.kryo.testkit.AbstractAkkaTest
 
+import java.nio.ByteBuffer
 import scala.collection.immutable.{HashMap, TreeMap}
 import scala.collection.mutable.AnyRefMap
+import scala.util.Try
 
 object TransformationSerializationTest {
   private val defaultConfig =
@@ -95,6 +97,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[TreeMap[String, Any]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[TreeMap[String, Any]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize immutable HashMap[String,Any] successfully" in {
@@ -112,6 +125,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[HashMap[String, Any]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[HashMap[String, Any]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize mutable AnyRefMap[String,Any] successfully" in {
@@ -129,6 +153,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[AnyRefMap[String, Any]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[AnyRefMap[String, Any]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize mutable HashMap[String,Any] successfully" in {
@@ -146,6 +181,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[scala.collection.mutable.HashMap[String, Any]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[scala.collection.mutable.HashMap[String, Any]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   // Sets
@@ -159,6 +205,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[scala.collection.immutable.HashSet[String]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[scala.collection.immutable.HashSet[String]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize immutable TreeSet[String] successfully" in {
@@ -171,6 +228,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[scala.collection.immutable.TreeSet[String]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[scala.collection.immutable.TreeSet[String]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize mutable HashSet[String] successfully" in {
@@ -183,6 +251,17 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[scala.collection.mutable.HashSet[String]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[scala.collection.mutable.HashSet[String]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 
   it should "serialize and deserialize mutable TreeSet[String] successfully" in {
@@ -195,5 +274,16 @@ abstract class TransformationSerializationTest(name: String, config: String) ext
 
     val deserialized = serialization.deserialize(serialized.get, classOf[scala.collection.mutable.TreeSet[String]])
     deserialized shouldBe util.Success(tm)
+
+    val bufferSerializer = serialization.findSerializerFor(tm).asInstanceOf[ByteBufferSerializer]
+    val bb = ByteBuffer.allocate(serialized.get.length * 2)
+
+    val bufferSerialized = Try(bufferSerializer.toBinary(tm, bb))
+    bufferSerialized shouldBe a[util.Success[_]]
+
+    bb.flip()
+
+    val bufferDeserialized = Try(bufferSerializer.fromBinary(bb, classOf[scala.collection.mutable.TreeSet[String]].getClass.getName))
+    bufferDeserialized shouldBe util.Success(tm)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val scalacStrictOptions = Seq(
         )
       case "3.0.0-RC2" =>
         Seq(
-          "-Xfatal-warnings",
+          //"-Xfatal-warnings", enable once dotty supports @nowarn
           "-Ycheck-all-patmat"
         )
     }


### PR DESCRIPTION
This PR implements Artery's `ByteBufferSerializer` interface and adds test coverage. References #112.

The most optimized case is direct serialization/deserialization into/from the `ByteBuffer`. If one or more transformations are applied, `Array[Byte]` representation is used for the intermediate steps and the `ByteBuffer` only at the periphery.

Public API changes:
* Deprecated `DefaultQueueBuilder.build` in favor of a future-proofed generic `DefaultQueueBuilder.build[T]`

Thanks in advance for your reviews and feedback.