### PR TITLE
Evaluate/Drop Java8 Support

### DIFF
--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 15 ]
+        java: [ 11, 15 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We provide several versions of the library:
 
 Version | Akka & Kryo Compatibility | Available Scala Versions  | Tested with                                                                            |
 --------|---------------------------|---------------------------|----------------------------------------------------------------------------------------|
-v2.2.x  | Akka-2.5,2.6 and Kryo-5.1 | 2.12,2.13,3.0             | JDK: OpenJdk8,OpenJdk11,OpenJdk15  Scala: 2.12.13,2.13.5,3.0.0-RC2 Akka: 2.5.32,2.6.14 |
+v2.2.x  | Akka-2.5,2.6 and Kryo-5.1 | 2.12,2.13,3.0             | JDK: OpenJdk11,OpenJdk15           Scala: 2.12.13,2.13.5,3.0.0-RC2 Akka: 2.5.32,2.6.14 |
 v2.1.x  | Akka-2.5,2.6 and Kryo-5.0 | 2.12,2.13                 | JDK: OpenJdk8,OpenJdk11,OpenJdk15  Scala: 2.12.13,2.13.4 Akka: 2.5.32,2.6.12           |
 v2.0.x  | Akka-2.5,2.6 and Kryo-5.0 | 2.12,2.13                 | JDK: OpenJdk8,OpenJdk11,OpenJdk13  Scala: 2.12.12,2.13.3 Akka: 2.5.32,2.6.10           |
 v1.1.x  | Akka-2.5,2.6 and Kryo-4.0 | 2.12,2.13                 | JDK: OpenJdk8,OpenJdk11,OpenJdk13  Scala: 2.12.11,2.13.2 Akka: 2.5.26,2.6.4            |
@@ -54,6 +54,8 @@ For past versions see [Legacy.md](Legacy.md).
 From 2.1.0 onward we also provide support for akka-typed. This is done as a separate artifact so that the standard does not pull all the typed akka dependencies.
 * Include:
   `libraryDependencies += "io.altoo" %% "akka-kryo-serialization-typed" % "2.2.0"`
+
+Version 2.2.0 drops java 8 support in favor of optimizations using ByteBuffer. 
 
 Note that we use semantic versioning - see [semver.org](https://semver.org/).
 

--- a/README.md
+++ b/README.md
@@ -149,15 +149,15 @@ below) and inside it you registerclasses of a few objects that are typically
 used by your application, for example:
 
 ```scala
-    kryo.register(myObj1.getClass);
-    kryo.register(myObj2.getClass);
+    kryo.register(myObj1.getClass)
+    kryo.register(myObj2.getClass)
 ```
 
 Obviously, you can also explicitly assign IDs to your classes in the initializer,
 if you wish:
 
 ```scala
-    kryo.register(myObj3.getClass, 123);
+    kryo.register(myObj3.getClass, 123)
 ```
 
 If you use this library as an alternative serialization method when sending messages
@@ -353,7 +353,7 @@ And finally declare the custom serializer in the `akka.actor.serializers` sectio
 ```
 
 
-Kryo shaded and ASM
+Kryo shaded and ASM (pre 2.x)
 -----------------------------
 Kryo depends on [ASM](https://asm.ow2.io), which is used by many different projects in different versions.
 This can lead to unintended version conflicts. To avoid this, Kryo provides a [shaded](https://maven.apache.org/plugins/maven-shade-plugin/) 
@@ -364,7 +364,7 @@ If you prefer to re-use Kryo you can override the dependency (but be sure to pic
     
 ```scala
 lazy val kryoSerializationDeps = Seq(
-  "io.altoo" %% "akka-kryo-serialization" % "1.0.0" excludeAll(ExclusionRule("com.esotericsoftware", "kryo-shaded")),
+  "io.altoo" %% "akka-kryo-serialization" % "1.0.0" excludeAll ExclusionRule("com.esotericsoftware", "kryo-shaded"),
   "com.esotericsoftware" % "kryo" % "4.0.2"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ From 2.1.0 onward we also provide support for akka-typed. This is done as a sepa
 * Include:
   `libraryDependencies += "io.altoo" %% "akka-kryo-serialization-typed" % "2.2.0"`
 
-Version 2.2.0 drops java 8 support in favor of optimizations using ByteBuffer. 
+Version 2.2.0 requires JDK 11 or higher in favor of optimizations using ByteBuffer. 
 
 Note that we use semantic versioning - see [semver.org](https://semver.org/).
 

--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/Transformer.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/Transformer.scala
@@ -1,16 +1,15 @@
 package io.altoo.akka.serialization.kryo
 
-import akka.annotation.InternalApi
-import net.jpountz.lz4.LZ4Factory
-
-import java.lang.reflect.Method
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.SecureRandom
-import java.util.zip.Deflater
+import java.util.zip.{Deflater, Inflater}
+import akka.annotation.InternalApi
+
 import javax.crypto.Cipher
 import javax.crypto.spec.{GCMParameterSpec, SecretKeySpec}
+import net.jpountz.lz4.LZ4Factory
+
 import scala.collection.mutable
-import scala.util.Try
 
 @InternalApi
 private[kryo] class KryoTransformer(transformations: List[Transformer]) {
@@ -59,7 +58,7 @@ trait Transformer {
   def toBinary(inputBuff: Array[Byte]): Array[Byte]
 
   def toBinary(inputBuff: Array[Byte], outputBuff: ByteBuffer): Unit
-  = outputBuff.put(toBinary(inputBuff))
+    = outputBuff.put(toBinary(inputBuff))
 
   def fromBinary(inputBuff: Array[Byte]): Array[Byte]
 
@@ -111,146 +110,114 @@ class LZ4KryoCompressor extends Transformer {
   }
 }
 
-object ZipKryoCompressor {
-  import java.security.{AccessController, PrivilegedAction}
-  import java.util.zip.Inflater
+class ZipKryoCompressor extends Transformer {
 
-  private val javaMajorVersion: Int = {
-    // FIXME replace with Runtime.version() when we no longer support Java 8
-    // See Oracle section 1.5.3 at:
-    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
-    val version = System.getProperty("java.specification.version").split('.')
-    val majorString =
-      if (version(0) == "1") version(1) // Java 8 will be 1.8
-      else version(0) // later will be 9, 10, 11 etc
-    majorString.toInt
+  override def toBinary(inputBuff: Array[Byte]): Array[Byte] = {
+    val deflater = new Deflater(Deflater.BEST_SPEED)
+    val inputSize = inputBuff.length
+    val outputBuff = new mutable.ArrayBuilder.ofByte
+    outputBuff += (inputSize & 0xff).toByte
+    outputBuff += (inputSize >> 8 & 0xff).toByte
+    outputBuff += (inputSize >> 16 & 0xff).toByte
+    outputBuff += (inputSize >> 24 & 0xff).toByte
+
+    deflater.setInput(inputBuff)
+    deflater.finish()
+    val buff = new Array[Byte](4096)
+
+    while (!deflater.finished) {
+      val n = deflater.deflate(buff)
+      outputBuff ++= buff.take(n)
+    }
+    deflater.end()
+    outputBuff.result()
   }
 
-  //jdk dependent method since java8 only has byte[] whereas java>11 has bytebuffer
-  private val deflatorDeflate: Option[Method] = {
-    if (javaMajorVersion >= 11) {
-      AccessController.doPrivileged(new PrivilegedAction[Option[Method]]() {
-        override def run(): Option[Method] = Try {
-          classOf[Inflater].getDeclaredMethod("deflate", classOf[ByteBuffer])
-        }.toOption
-      });
-    }
+  override def toBinary(inputBuff: Array[Byte], outputBuff: ByteBuffer): Unit = {
+    val deflater = new Deflater(Deflater.BEST_SPEED)
+    val inputSize = inputBuff.length
+    outputBuff.order(ByteOrder.LITTLE_ENDIAN).putInt(inputSize)
+
+    deflater.setInput(inputBuff)
+    deflater.finish()
+    deflater.deflate(outputBuff)
+    deflater.end()
   }
 
-  class ZipKryoCompressor extends Transformer {
-
-    override def toBinary(inputBuff: Array[Byte]): Array[Byte] = {
-      val deflater = new Deflater(Deflater.BEST_SPEED)
-      val inputSize = inputBuff.length
-      val outputBuff = new mutable.ArrayBuilder.ofByte
-      outputBuff += (inputSize & 0xff).toByte
-      outputBuff += (inputSize >> 8 & 0xff).toByte
-      outputBuff += (inputSize >> 16 & 0xff).toByte
-      outputBuff += (inputSize >> 24 & 0xff).toByte
-
-      deflater.setInput(inputBuff)
-      deflater.finish()
-      val buff = new Array[Byte](4096)
-
-      while (!deflater.finished) {
-        val n = deflater.deflate(buff)
-        outputBuff ++= buff.take(n)
-      }
-      deflater.end()
-      outputBuff.result()
-    }
-
-    override def toBinary(inputBuff: Array[Byte], outputBuff: ByteBuffer): Unit = {
-      val deflater = new Deflater(Deflater.BEST_SPEED)
-      val inputSize = inputBuff.length
-      outputBuff.order(ByteOrder.LITTLE_ENDIAN).putInt(inputSize)
-
-      deflater.setInput(inputBuff)
-      deflater.finish()
-      if (deflatorDeflate.isDefined) {
-        //use via reflection
-        deflater.deflate(outputBuff)
-      }
-      else {
-        //must use byte[] instead...
-      }
-      deflater.end()
-    }
-
-    override def fromBinary(inputBuff: Array[Byte]): Array[Byte] = {
-      fromBinary(ByteBuffer.wrap(inputBuff))
-    }
-
-    override def fromBinary(inputBuff: ByteBuffer): Array[Byte] = {
-      val inflater = new Inflater()
-      val size = inputBuff.order(ByteOrder.LITTLE_ENDIAN).getInt()
-      val outputBuff = new Array[Byte](size)
-      inflater.setInput(inputBuff)
-      inflater.inflate(ByteBuffer.wrap(outputBuff))
-      inflater.end()
-      outputBuff
-    }
+  override def fromBinary(inputBuff: Array[Byte]): Array[Byte] = {
+    fromBinary(ByteBuffer.wrap(inputBuff))
   }
 
-  class KryoCryptographer(key: Array[Byte], mode: String, ivLength: Int) extends Transformer {
-    private final val AuthTagLength = 128
+  override def fromBinary(inputBuff: ByteBuffer): Array[Byte] = {
+    val inflater = new Inflater()
+    val size = inputBuff.order(ByteOrder.LITTLE_ENDIAN).getInt()
+    val outputBuff = new Array[Byte](size)
+    inflater.setInput(inputBuff)
+    inflater.inflate(ByteBuffer.wrap(outputBuff))
+    inflater.end()
+    outputBuff
+  }
+}
 
-    if (ivLength < 12 || ivLength >= 16) {
+class KryoCryptographer(key: Array[Byte], mode: String, ivLength: Int) extends Transformer {
+  private final val AuthTagLength = 128
+
+  if (ivLength < 12 || ivLength >= 16) {
+    throw new IllegalStateException("invalid iv length")
+  }
+
+  private[this] val keySpec = new SecretKeySpec(key, "AES")
+  private lazy val random = new SecureRandom()
+
+  override def toBinary(plaintext: Array[Byte]): Array[Byte] = {
+    val cipher = Cipher.getInstance(mode)
+    // fill randomized IV
+    val iv = new Array[Byte](ivLength)
+    random.nextBytes(iv)
+    // set up encryption
+    val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
+    cipher.init(Cipher.ENCRYPT_MODE, keySpec, parameterSpec)
+    val ciphertext = cipher.doFinal(plaintext)
+    // concat IV length, IV and ciphertext
+    val byteBuffer = ByteBuffer.allocate(4 + iv.length + ciphertext.length)
+    byteBuffer.putInt(iv.length)
+    byteBuffer.put(iv)
+    byteBuffer.put(ciphertext)
+    byteBuffer.array // output
+  }
+
+  override def toBinary(inputBuff: Array[Byte], outputBuff: ByteBuffer): Unit = {
+    val cipher = Cipher.getInstance(mode)
+    // fill randomized IV
+    val iv = new Array[Byte](ivLength)
+    random.nextBytes(iv)
+    // set up encryption
+    val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
+    cipher.init(Cipher.ENCRYPT_MODE, keySpec, parameterSpec)
+    // concat IV length, IV and ciphertext
+    outputBuff.putInt(iv.length)
+    outputBuff.put(iv)
+    cipher.doFinal(ByteBuffer.wrap(inputBuff), outputBuff)
+  }
+
+  override def fromBinary(input: Array[Byte]): Array[Byte] = {
+    fromBinary(ByteBuffer.wrap(input))
+  }
+
+  override def fromBinary(inputBuff: ByteBuffer): Array[Byte] = {
+    val cipher = Cipher.getInstance(mode)
+    // extract IV length, IV and ciphertext
+    val ivLength = inputBuff.getInt()
+    if (ivLength < 12 || ivLength >= 16) { // check input parameter to protect against attacks
       throw new IllegalStateException("invalid iv length")
     }
-
-    private[this] val keySpec = new SecretKeySpec(key, "AES")
-    private lazy val random = new SecureRandom()
-
-    override def toBinary(plaintext: Array[Byte]): Array[Byte] = {
-      val cipher = Cipher.getInstance(mode)
-      // fill randomized IV
-      val iv = new Array[Byte](ivLength)
-      random.nextBytes(iv)
-      // set up encryption
-      val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
-      cipher.init(Cipher.ENCRYPT_MODE, keySpec, parameterSpec)
-      val ciphertext = cipher.doFinal(plaintext)
-      // concat IV length, IV and ciphertext
-      val byteBuffer = ByteBuffer.allocate(4 + iv.length + ciphertext.length)
-      byteBuffer.putInt(iv.length)
-      byteBuffer.put(iv)
-      byteBuffer.put(ciphertext)
-      byteBuffer.array // output
-    }
-
-    override def toBinary(inputBuff: Array[Byte], outputBuff: ByteBuffer): Unit = {
-      val cipher = Cipher.getInstance(mode)
-      // fill randomized IV
-      val iv = new Array[Byte](ivLength)
-      random.nextBytes(iv)
-      // set up encryption
-      val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
-      cipher.init(Cipher.ENCRYPT_MODE, keySpec, parameterSpec)
-      // concat IV length, IV and ciphertext
-      outputBuff.putInt(iv.length)
-      outputBuff.put(iv)
-      cipher.doFinal(ByteBuffer.wrap(inputBuff), outputBuff)
-    }
-
-    override def fromBinary(input: Array[Byte]): Array[Byte] = {
-      fromBinary(ByteBuffer.wrap(input))
-    }
-
-    override def fromBinary(inputBuff: ByteBuffer): Array[Byte] = {
-      val cipher = Cipher.getInstance(mode)
-      // extract IV length, IV and ciphertext
-      val ivLength = inputBuff.getInt()
-      if (ivLength < 12 || ivLength >= 16) { // check input parameter to protect against attacks
-        throw new IllegalStateException("invalid iv length")
-      }
-      val iv = new Array[Byte](ivLength)
-      inputBuff.get(iv)
-      val ciphertext = new Array[Byte](inputBuff.remaining())
-      inputBuff.get(ciphertext)
-      // set up decryption
-      val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
-      cipher.init(Cipher.DECRYPT_MODE, keySpec, parameterSpec)
-      cipher.doFinal(ciphertext) // plaintext
-    }
+    val iv = new Array[Byte](ivLength)
+    inputBuff.get(iv)
+    val ciphertext = new Array[Byte](inputBuff.remaining())
+    inputBuff.get(ciphertext)
+    // set up decryption
+    val parameterSpec = new GCMParameterSpec(AuthTagLength, iv)
+    cipher.init(Cipher.DECRYPT_MODE, keySpec, parameterSpec)
+    cipher.doFinal(ciphertext) // plaintext
   }
+}


### PR DESCRIPTION
This drops java8 support in favor of using bytebuffer optimized methods from java11 onwards