### PR TITLE
fixes

### DIFF
--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -17,6 +17,6 @@ jobs:
           java-version: '${{ matrix.java }}'
           distribution: 'adopt'
       - name: Run tests with Akka 2.6 and Scala 2.12,2.13,3.0
-        run: sbt +test
+        run: sbt +test +doc
       - name: Run tests with Akka 2.5 and Scala 2.13
-        run: sbt -Dakka.build.version=2.5.32 clean test
+        run: sbt -Dakka.build.version=2.5.32 clean test doc

--- a/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
+++ b/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala
@@ -39,7 +39,7 @@ class DefaultKryoInitializer {
 
 
   /**
-   * Overwrite to change default enumeration serializer to [[EnumerationNameSerializer]] instead of [[EnumerationSerializer]].
+   * Overwrite to change default enumeration serializer to [[io.altoo.akka.serialization.kryo.serializer.scala.EnumerationNameSerializer]] instead of [[io.altoo.akka.serialization.kryo.serializer.scala.EnumerationSerializer]].
    * Release 2.5.0 will change default.
    */
   protected def defaultEnumerationSerializer: Class[_ <: Serializer[Enumeration#Value]] = classOf[EnumerationSerializer]


### PR DESCRIPTION
[error] /home/dsc/git/akka-kryo-serialization/akka-kryo-serialization/src/main/scala/io/altoo/akka/serialization/kryo/DefaultKryoInitializer.scala:41:3: Could not find any member to link for "EnumerationSerializer".
[error]   /**
[error]   ^
[error] one error found
[error] stack trace is suppressed; run last akka-kryo-serialization / Compile / doc for the full output
[error] (akka-kryo-serialization / Compile / doc) Scaladoc generation failed