### PR TITLE
Use native scala 3 akka artifacts.

### DIFF
--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -17,5 +17,6 @@ jobs:
           java-version: '${{ matrix.java }}'
           distribution: 'temurin'
           cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
       - name: Run tests with Akka 2.6 and Scala 2.12,2.13,3.1
         run: sbt +test +doc

--- a/.github/workflows/fullTest.yml
+++ b/.github/workflows/fullTest.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '${{ matrix.java }}'
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: 'sbt'
       - name: Run tests with Akka 2.6 and Scala 2.12,2.13,3.1
         run: sbt +test +doc

--- a/.github/workflows/pullCi.yml
+++ b/.github/workflows/pullCi.yml
@@ -17,5 +17,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
       - name: Run tests with Akka 2.6 and Scala 2.12,2.13,3.0
         run: sbt +test

--- a/.github/workflows/pullCi.yml
+++ b/.github/workflows/pullCi.yml
@@ -10,13 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 15
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '15'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'sbt'
       - name: Run tests with Akka 2.6 and Scala 2.12,2.13,3.0
         run: sbt +test
-      - name: Run tests with Akka 2.5 and Scala 2.13
-        run: sbt -Dakka.build.version=2.5.32 clean test

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val mainScalaVersion = "3.3.1"
 val secondayScalaVersions = Seq("2.12.18", "2.13.12")
 
 val kryoVersion = "5.4.0"
-val defaultAkkaVersion = "2.6.20"
+val defaultAkkaVersion = "2.6.21"
 val akkaVersion =
   System.getProperty("akka.build.version", defaultAkkaVersion) match {
     case "default" => defaultAkkaVersion
@@ -69,7 +69,7 @@ lazy val pekkoCompat: Project = Project("akka-kryo-serialization-pekko-compat", 
 // Dependencies
 lazy val coreDeps = Seq(
   "com.esotericsoftware" % "kryo" % kryoVersion,
-  ("com.typesafe.akka" %% "akka-actor" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  ("com.typesafe.akka" %% "akka-actor" % akkaVersion),
   "org.agrona" % "agrona" % "1.15.1", // should match akka-remote/aeron inherited version
   "org.lz4" % "lz4-java" % "1.8.0",
   "commons-io" % "commons-io" % "2.11.0" % Test,
@@ -78,14 +78,13 @@ lazy val coreDeps = Seq(
 lazy val typedDeps = Seq(
   "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test
-).map(_.cross(CrossVersion.for3Use2_13))
+)
 
 lazy val testingDeps = Seq(
   "org.scalatest" %% "scalatest" % "3.2.14" % Test,
   "ch.qos.logback" % "logback-classic" % "1.2.11" % Test,
-  ("com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test).cross(CrossVersion.for3Use2_13),
-  ("com.typesafe.akka" %% "akka-persistence" % akkaVersion % Test).cross(CrossVersion.for3Use2_13)
-)
+  ("com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test),
+  ("com.typesafe.akka" %% "akka-persistence" % akkaVersion % Test))
 
 
 // Settings


### PR DESCRIPTION
Upgrade to latest akka 2.6 patch version (2.6.21) and use native Scala 3 artifacts, instead of 2.13 cross-versions. These are binary imcompatible, at least with later akka versions on Scala 3.
Fixes issue #298 